### PR TITLE
Add cluster name length info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Automated DockerHub builds are also triggered on new releases, located [here](ht
 ## Provisioning a cluster
 - Grab, customize and export the environment variables from the **AWS ElasticSearch - Provisioning Setup** LastPass note.
 - The cluster name will be `${CF_TEMPLATE}-${DELIVERY_CLUSTER}` - eg, `upp-concepts-prod-uk`.
-- the cluster name length must be less than or equal to 28
+- The cluster name length must be less than or equal to 28
 - If provisioning a cluster that has previously had a snapshot taken, and you wish to restore the latest ES snapshot, set `$RESTORE_ES_SNAPSHOT"` to `true`.
 - Run the following Docker commands:
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Automated DockerHub builds are also triggered on new releases, located [here](ht
 ## Provisioning a cluster
 - Grab, customize and export the environment variables from the **AWS ElasticSearch - Provisioning Setup** LastPass note.
 - The cluster name will be `${CF_TEMPLATE}-${DELIVERY_CLUSTER}` - eg, `upp-concepts-prod-uk`.
+- the cluster name length must be less than or equal to 28
 - If provisioning a cluster that has previously had a snapshot taken, and you wish to restore the latest ES snapshot, set `$RESTORE_ES_SNAPSHOT"` to `true`.
 - Run the following Docker commands:
 ```


### PR DESCRIPTION
- see error on the `upp-concepts-k8s-delivery-upp-uk` CF in AWS console

``` 	1 validation error detected: Value 'upp-concepts-k8s-delivery-upp-uk' at 'domainName' failed to satisfy constraint: Member must have length less than or equal to 28```